### PR TITLE
Generate composite HSI - Model 1

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ import os
 import config
 import numpy as np
 import tensorflow as tf
-from extract import extract_bands
+from .extract import extract_bands
 from utils import pair_img, load_rgb_images, load_hsi_images_from_all_folders, discriminator_loss, generator_loss, mean_squared_error, peak_signal_to_noise_ratio, spectral_angle_mapper, visualize_generated_images
 from model import Generator, Discriminator
 from tensorflow.keras.preprocessing.image import ImageDataGenerator
@@ -73,6 +73,9 @@ def train_gan(rgb_images, hsi_images, generator: Generator, discriminator: Discr
             mse = mean_squared_error(hsi_batch, generated_hsi_resized)
             psnr = peak_signal_to_noise_ratio(hsi_batch, generated_hsi_resized)
             sam = spectral_angle_mapper(hsi_batch, generated_hsi_resized)
+
+            visualize_generated_images(
+                augmented_rgb_batch, generated_hsi, hsi_batch, epoch, i // config.BATCH_SIZE)
 
             """
             with summary_writer.as_default():

--- a/utils.py
+++ b/utils.py
@@ -241,16 +241,30 @@ def visualize_generated_images(rgb_batch, generated_hsi, hsi_batch, epoch, batch
         axes[0, i].axis('off')
         axes[0, i].set_title('RGB Input')
 
-        # Display Generated HSI
-        # Select first 3 channels as an RGB approximation
-        axes[1, i].imshow(gen_img[:, :, :3])
+        # Display Generated HSI as a composite image
+        gen_img_composite = gen_img.mean(axis=-1)  # Average intensity across all channels
+        axes[1, i].imshow(gen_img_composite, cmap='gray')
         axes[1, i].axis('off')
-        axes[1, i].set_title('Generated HSI')
+        axes[1, i].set_title('Generated HSI Composite')
 
-        # Display Real HSI
-        axes[2, i].imshow(real_img[:, :, :3])  # Same here for real HSI
+        # Display Real HSI as a composite image
+        real_img_composite = real_img.mean(axis=-1)  # Average intensity across all channels
+        axes[2, i].imshow(real_img_composite, cmap='gray')
         axes[2, i].axis('off')
-        axes[2, i].set_title('Real HSI')
+        axes[2, i].set_title('Real HSI Composite')
 
     plt.suptitle(f'Epoch {epoch}, Batch {batch}')
-    plt.show()
+    
+    # Save the plot to a file
+    output_dir = "output_images"
+    if not os.path.exists(output_dir):
+        print(f"Creating directory: {output_dir}")
+        os.makedirs(output_dir, exist_ok=True)
+    else:
+        print(f"Directory already exists: {output_dir}")
+    
+    file_path = os.path.join(output_dir, f'epoch_{epoch}_batch_{batch}.png')
+    print(f"Saving plot to: {file_path}")
+    plt.savefig(file_path)
+    plt.close()
+    print(f"Plot saved successfully.")

--- a/utils.py
+++ b/utils.py
@@ -241,17 +241,17 @@ def visualize_generated_images(rgb_batch, generated_hsi, hsi_batch, epoch, batch
         axes[0, i].axis('off')
         axes[0, i].set_title('RGB Input')
 
+        # Display Original HSI as a composite image
+        real_img_composite = real_img.mean(axis=-1)  # Average intensity across all channels
+        axes[1, i].imshow(real_img_composite, cmap='gray')
+        axes[1, i].axis('off')
+        axes[1, i].set_title('Original HSI Composite')
+
         # Display Generated HSI as a composite image
         gen_img_composite = gen_img.mean(axis=-1)  # Average intensity across all channels
-        axes[1, i].imshow(gen_img_composite, cmap='gray')
-        axes[1, i].axis('off')
-        axes[1, i].set_title('Generated HSI Composite')
-
-        # Display Real HSI as a composite image
-        real_img_composite = real_img.mean(axis=-1)  # Average intensity across all channels
-        axes[2, i].imshow(real_img_composite, cmap='gray')
+        axes[2, i].imshow(gen_img_composite, cmap='gray')
         axes[2, i].axis('off')
-        axes[2, i].set_title('Real HSI Composite')
+        axes[2, i].set_title('Generated HSI Composite')
 
     plt.suptitle(f'Epoch {epoch}, Batch {batch}')
     


### PR DESCRIPTION
Resulting Plot
Each plot saved in the PNG files will look something like this:

![image](https://github.com/user-attachments/assets/e1655758-21b0-4b2c-8fdc-facd9cd6c5c3)

This layout allows us to compare the RGB input, original HSI, and generated HSI side by side for each sample in the batch. The composite images provide a simplified view of the HSI data by averaging the intensity values across all channels.